### PR TITLE
[tests] clang requires more explicit types for decltype comparison here.

### DIFF
--- a/tests/test_tuple_for_each.cc
+++ b/tests/test_tuple_for_each.cc
@@ -37,7 +37,7 @@ TEST(TestTupleForEach, SameType) {
   }
 
   {
-    auto t_original = std::make_tuple(1, (double)2.1f, 3);
+	auto t_original = std::make_tuple(1, static_cast<double>(2.1f), 3);
     tupleutils::tuple_for_each<for_each_simple>(t_original);
   }
 }
@@ -54,7 +54,7 @@ public:
 
 TEST(TestTupleForEach, SameTypesWithExtra) {
   {
-    auto t_original = std::make_tuple(1, (double)2.1f, 3);
+	auto t_original = std::make_tuple(1, static_cast<double>(2.1f), 3);
     tupleutils::tuple_for_each<for_each_simple_with_extras>(
       t_original, 89, "eightynine");
   }
@@ -71,7 +71,7 @@ public:
 
 TEST(TestTupleForEach, SameTypesWithNonConstExtra) {
   {
-    auto t_original = std::make_tuple(1, (double)2.1f, 3);
+	auto t_original = std::make_tuple(1, static_cast<double>(2.1f), 3);
     int extra = 0;
 
     tupleutils::tuple_for_each<for_each_simple_with_nonconst_extras>(t_original, extra);
@@ -131,7 +131,7 @@ public:
 };
 
 TEST(TestTupleForEach, MultipleTypes) {
-  auto t_original = std::make_tuple(1, (double)2.1f, std::string("3"));
+  auto t_original = std::make_tuple(1, static_cast<double>(2.1f), std::string("3"));
   tupleutils::tuple_for_each<visitor_with_specializations>(t_original);
 }
 
@@ -203,7 +203,7 @@ TEST(TestTupleForEach, EmptyTuple) {
 // TODO: Does this test function itself need to be constexpr,
 // and if so, how can we do that with googletest?
 TEST(TestTupleForEach, ConstExpr) {
-  constexpr auto t_original = std::make_tuple(1, (double)2.1f, "3");
+  constexpr auto t_original = std::make_tuple(1, static_cast<double>(2.1f), "3");
   tupleutils::tuple_for_each<visitor_with_specializations>(t_original);
 }
 

--- a/tests/test_tuple_transform_each.cc
+++ b/tests/test_tuple_transform_each.cc
@@ -44,7 +44,7 @@ TEST(TestTupleTransformEach, TypeSameTypes) {
 TEST(TestTupleTransformEach, SameTypes) {
   {
     auto t_original = std::make_tuple(1, 2, 3);
-    auto t_transformed =
+	std::tuple<std::string, std::string, std::string> t_transformed =
       tupleutils::tuple_transform_each<transform_to_string>(t_original);
     auto t_expected =
       std::make_tuple(std::string("1"), std::string("2"), std::string("3"));
@@ -62,8 +62,8 @@ TEST(TestTupleTransformEach, SameTypes) {
   }
 
   {
-    auto t_original = std::make_tuple(1, (double)2.1f, 3);
-    auto t_transformed =
+	auto t_original = std::make_tuple(1, static_cast<double>(2.1f), 3);
+	std::tuple<std::string, std::string, std::string> t_transformed =
       tupleutils::tuple_transform_each<transform_to_string>(t_original);
     auto t_expected =
       std::make_tuple(std::string("1"), std::string("2"), std::string("3"));
@@ -130,8 +130,8 @@ TEST(TestTupleTransformEach, TypeMultipeTypes) {
 }
 
 TEST(TestTupleTransformEach, MultipleTypes) {
-  auto t_original = std::make_tuple(1, (double)2.1f, std::string("3"));
-  auto t_transformed =
+  auto t_original = std::make_tuple(1, static_cast<double>(2.1f), std::string("3"));
+  std::tuple<std::string, char, int> t_transformed =
     tupleutils::tuple_transform_each<transform_to_something>(t_original);
   auto t_expected = std::make_tuple(std::string("1"), '2', 3);
 
@@ -180,7 +180,7 @@ TEST(TestTupleTransformEach, StdRef) {
   int b = 2;
   int c = 3;
   auto t_original = std::make_tuple(std::ref(a), std::ref(b), std::ref(c));
-  auto t_transformed =
+  std::tuple<std::string, std::string, std::string> t_transformed =
     tupleutils::tuple_transform_each<transform_to_string>(t_original);
   auto t_expected =
     std::make_tuple(std::string("1"), std::string("2"), std::string("3"));
@@ -235,7 +235,7 @@ TEST(TestTupleTransformEach, StdRefNonCopyable) {
   NonCopyable b(2);
   NonCopyable c(3);
   auto t_original = std::make_tuple(std::ref(a), std::ref(b), std::ref(c));
-  auto t_transformed =
+  std::tuple<std::string, std::string, std::string> t_transformed =
     tupleutils::tuple_transform_each<transform_noncopyable_to_string>(t_original);
   auto t_expected =
     std::make_tuple(std::string("1"), std::string("2"), std::string("3"));
@@ -291,7 +291,7 @@ public:
   static
   char
   transform(int from) {
-    return 'a' + from;
+	return 'a' + static_cast<char>(from);
   }
 };
 
@@ -303,7 +303,7 @@ public:
   static
   int
   transform(double from) {
-    return (int)from;
+	return static_cast<int>(from);
   }
 };
 


### PR DESCRIPTION
This also fixes the old-style casts (which are warnings in `clangs` default compilation mode).
I have manually run the `test_tuple_transform_each` on my OSX and can verify that all 9 tests run successfully. 
