### PR TITLE
WIP: Use googletest via pkg-config instead of as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "googletest"]
-	path = googletest
-	url = https://github.com/google/googletest.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,53 +36,12 @@ library_includedir = $(includedir)/$(MURRAYC_TUPLE_UTILS_MODULE_NAME)
 nobase_library_include_HEADERS = $(h_sources_public)
 
 
-# Build googletest:
-gtest_top = googletest/googletest
-check_LTLIBRARIES = libgtest.la
-libgtest_la_SOURCES = googletest/googletest/src/gtest-all.cc \
-		      googletest/googletest/src/gtest_main.cc
 
-libgtest_la_CPPFLAGS = -I$(top_srcdir)/$(gtest_top)/include -I$(top_srcdir)/$(gtest_top) \
-		       $(PROJECT_GTEST_WXXFLAGS)
-libgtest_la_LDFLAGS = -pthread
-EXTRA_DIST = $(gtest_top)/src/gtest-all.cc \
-	     $(gtest_top)/src/gtest-filepath.cc \
-	     $(gtest_top)/src/gtest-printers.cc \
-	     $(gtest_top)/src/gtest.cc \
-	     $(gtest_top)/src/gtest_main.cc \
-	     $(gtest_top)/src/gtest-matchers.cc \
-	     $(gtest_top)/src/gtest-test-part.cc \
-	     $(gtest_top)/src/gtest-death-test.cc \
-	     $(gtest_top)/src/gtest-port.cc \
-	     $(gtest_top)/src/gtest-typed-test.cc \
-	     $(gtest_top)/src/gtest-internal-inl.h \
-	     $(gtest_top)/include/gtest/gtest-death-test.h \
-	     $(gtest_top)/include/gtest/gtest_pred_impl.h \
-	     $(gtest_top)/include/gtest/gtest-test-part.h \
-	     $(gtest_top)/include/gtest/gtest.h \
-	     $(gtest_top)/include/gtest/gtest-printers.h \
-	     $(gtest_top)/include/gtest/gtest-typed-test.h \
-	     $(gtest_top)/include/gtest/gtest-matchers.h \
-	     $(gtest_top)/include/gtest/gtest-message.h \
-	     $(gtest_top)/include/gtest/gtest_prod.h \
-	     $(gtest_top)/include/gtest/gtest-param-test.h \
-	     $(gtest_top)/include/gtest/gtest-spi.h \
-	     $(gtest_top)/include/gtest/internal/gtest-death-test-internal.h \
-	     $(gtest_top)/include/gtest/internal/gtest-port-arch.h \
-	     $(gtest_top)/include/gtest/internal/gtest-filepath.h \
-	     $(gtest_top)/include/gtest/internal/gtest-port.h \
-	     $(gtest_top)/include/gtest/internal/gtest-internal.h \
-	     $(gtest_top)/include/gtest/internal/gtest-string.h \
-	     $(gtest_top)/include/gtest/internal/gtest-type-util.h \
-	     $(gtest_top)/include/gtest/internal/gtest-param-util.h \
-	     $(gtest_top)/include/gtest/internal/custom/gtest.h \
-	     $(gtest_top)/include/gtest/internal/custom/gtest-printers.h \
-	     $(gtest_top)/include/gtest/internal/custom/gtest-port.h
-
-COMMON_CXXFLAGS = $(PROJECT_CFLAGS) $(PROJECT_WXXFLAGS) $(BOOST_CPPFLAGS)
+COMMON_CXXFLAGS = $(PROJECT_WXXFLAGS) $(BOOST_CPPFLAGS) \
+		  $(PROJECT_TEST_CFLAGS)
 COMMON_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) \
-		  -isystem $(top_srcdir)/$(gtest_top)/include
-COMMON_LIBS = $(PROJECT_LIBS) libgtest.la
+		  $(PROJECT_TEST_LIBS)
+COMMON_LIBS = $(PROJECT_TEST_LIBS)
 
 check_PROGRAMS = \
   tests/test_tuple_cat \

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ MM_ARG_ENABLE_DOCUMENTATION
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 AC_SUBST([LIBMURRAYC_TUPLE_UTILS_SO_VERSION], [0:0:0])
 
-#PKG_CHECK_MODULES([PROJECT], [])
+PKG_CHECK_MODULES([PROJECT_TESTS], [gtest_main])
 
 AC_LANG([C++])
 MM_ARG_ENABLE_WARNINGS([PROJECT_WXXFLAGS],


### PR DESCRIPTION
WIP: This would probably work if the googletest library was actually
packaged by Linux distros.
I added some notes about this here in an "Updated:" paragraph:
https://www.murrayc.com/permalink/2016/12/08/trying-googletest/