### PR TITLE
GitHub Actions: Use --enable-warnings=fatal

### DIFF
--- a/.github/workflows/autotools-clang-5.yml
+++ b/.github/workflows/autotools-clang-5.yml
@@ -17,7 +17,7 @@ jobs:
         export CXX=clang++-5.0
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |

--- a/.github/workflows/autotools-clang-6.yml
+++ b/.github/workflows/autotools-clang-6.yml
@@ -17,7 +17,7 @@ jobs:
         export CXX=clang++-6.0
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |

--- a/.github/workflows/autotools-clang-7.yml
+++ b/.github/workflows/autotools-clang-7.yml
@@ -17,7 +17,7 @@ jobs:
         export CXX=clang++-7
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |

--- a/.github/workflows/autotools-clang-8.yml
+++ b/.github/workflows/autotools-clang-8.yml
@@ -18,7 +18,7 @@ jobs:
         export CXX=clang++-8
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |

--- a/.github/workflows/autotools-gcc-7.yml
+++ b/.github/workflows/autotools-gcc-7.yml
@@ -17,7 +17,7 @@ jobs:
         export CXX=g++-7
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |

--- a/.github/workflows/autotools-gcc-8.yml
+++ b/.github/workflows/autotools-gcc-8.yml
@@ -17,7 +17,7 @@ jobs:
         export CXX=g++-8
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |

--- a/.github/workflows/autotools-gcc-9.yml
+++ b/.github/workflows/autotools-gcc-9.yml
@@ -18,7 +18,7 @@ jobs:
         export CXX=g++-9
         mkdir build
         cd build
-        ../autogen.sh
+        ../autogen.sh --enable-warnings=fatal
         make
     - name: Test
       run: |


### PR DESCRIPTION
This enables more warnings and makes the build fail if any happen.